### PR TITLE
Feature/reduce-events

### DIFF
--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -23,10 +23,14 @@ pub struct Controller {
     button_state: Vec<bool>,
     button_pressed: Vec<bool>,
     button_count: [i32; 7],
+    button_diff: bool,
+    button_count_diff: bool,
     scratch: scratch::Scratch,
     scratch_state: f64,
     scratch_activated: bool,
     scratch_count: i32,
+    scratch_diff: bool,
+    scratch_count_diff: bool,
 }
 
 impl Controller {
@@ -38,10 +42,14 @@ impl Controller {
             button_state: vec![false; 16],
             button_pressed: vec![false; 16],
             button_count: [0; 7],
+            button_diff: false,
+            button_count_diff: false,
             scratch: scratch::Scratch::new(),
             scratch_state: 0.0,
             scratch_activated: false,
             scratch_count: 0,
+            scratch_diff: false,
+            scratch_count_diff: false,
         }
     }
 
@@ -97,8 +105,9 @@ impl Controller {
         self.scratch_state = axisarray[0];
 
         // ボタン・スクラッチの作動状態を更新
-        self.button_pressed = self.button.check_pressed(self.button_state.clone());
-        self.scratch_activated = self.scratch.check_input(self.scratch_state);
+        (self.button_pressed, self.button_diff) =
+            self.button.check_pressed(self.button_state.clone());
+        (self.scratch_activated, self.scratch_diff) = self.scratch.check_input(self.scratch_state);
     }
 
     pub fn get_button_count(&self) -> [i32; 7] {
@@ -110,16 +119,21 @@ impl Controller {
     }
 
     pub fn update_count(&mut self) -> () {
+        self.button_count_diff = false;
+        self.scratch_count_diff = false;
+
         // ボタンカウントの更新
         for i in 0..7 {
             if self.button_pressed[i] {
                 self.button_count[i] += 1;
+                self.button_count_diff = true;
             }
         }
 
         // スクラッチカウントの更新
         if self.scratch_activated {
             self.scratch_count += 1;
+            self.scratch_count_diff = true;
         }
     }
 
@@ -145,5 +159,21 @@ impl Controller {
             }
         }
         true
+    }
+
+    pub fn get_button_diff(&self) -> bool {
+        self.button_diff
+    }
+
+    pub fn get_button_count_diff(&self) -> bool {
+        self.button_count_diff
+    }
+
+    pub fn get_scratch_diff(&self) -> bool {
+        self.scratch_diff
+    }
+
+    pub fn get_scratch_count_diff(&self) -> bool {
+        self.scratch_count_diff
     }
 }

--- a/src-tauri/src/controller/button.rs
+++ b/src-tauri/src/controller/button.rs
@@ -11,17 +11,22 @@ impl Button {
         }
     }
 
-    pub fn check_pressed(&mut self, button_state: Vec<bool>) -> Vec<bool> {
+    pub fn check_pressed(&mut self, button_state: Vec<bool>) -> (Vec<bool>, bool) {
         let mut button_pressed = vec![false; 16];
+        let mut button_diff = false;
 
         for i in 0..16 {
             if button_state[i] && !self.prev_button_state[i] {
                 button_pressed[i] = true;
             }
+
+            if button_state[i] != self.prev_button_state[i] {
+                button_diff = true;
+            }
         }
 
         self.prev_button_state = button_state.clone();
 
-        return button_pressed;
+        return (button_pressed, button_diff);
     }
 }

--- a/src-tauri/src/controller/scratch.rs
+++ b/src-tauri/src/controller/scratch.rs
@@ -27,21 +27,24 @@ impl Scratch {
         }
     }
 
-    pub fn check_input(&mut self, value: f64) -> bool {
+    pub fn check_input(&mut self, value: f64) -> (bool, bool) {
         let scratch_value: f64 = value;
         let mut scratch_active = self.prev_active;
         let mut scratch_dir = self.prev_dir;
 
         let mut scratch_started = false;
 
+        let mut scratch_diff = false;
+
         if !self.initialized {
             self.prev_value = scratch_value;
             self.initialized = true;
-            return false;
+            return (false, true);
         }
 
         if scratch_value != self.prev_value {
             scratch_active = true;
+            scratch_diff = true;
             self.counter = 0;
 
             let scratch_diff = scratch_value - self.prev_value;
@@ -74,6 +77,6 @@ impl Scratch {
         self.prev_active = scratch_active;
         self.prev_dir = scratch_dir;
 
-        return scratch_started;
+        return (scratch_started, scratch_diff);
     }
 }


### PR DESCRIPTION
Rust→View通信のCPU使用率がとんでもないことになっていたので以下のように改善した。
- Controllerモジュール側でボタン・皿の状態・カウントの更新の有無を保持するようにした
- mainでは更新がある場合のみViewに通信を送るようにした
- スクラッチの状態のみ間隔を20msに広げて定期的に送るようにしている